### PR TITLE
meta: Support encoding arbitrary types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ byte representation which is the IPLD Canonical CBOR format
 To encode a set of properties:
 
 ```
-obj, err := Encode(Properties{
+obj, err := Encode(map[string]string{
         "key1": "val1",
         "key2": "val2",
         "key3": "val3",
@@ -32,11 +32,11 @@ representation with `obj.RawData()`.
 Objects can be linked by assigning an object's CID as the value of a property:
 
 ```
-jane := MustEncode(Properties{"name": "Jane"})
-john := MustEncode(Properties{"name": "John"})
-jack := MustEncode(Properties{"name": "Jack"})
+jane := MustEncode(map[string]string{"name": "Jane"})
+john := MustEncode(map[string]string{"name": "John"})
+jack := MustEncode(map[string]string{"name": "Jack"})
 
-me := MustEncode(Properties{
+me := MustEncode(map[string]string{
         "sister": jane.Cid(),
         "children": []*cid.Cid{
                 john.Cid(),

--- a/doc.go
+++ b/doc.go
@@ -29,7 +29,7 @@ byte representation which is the IPLD Canonical CBOR format
 
 To encode a set of properties:
 
-	obj, err := Encode(Properties{
+	obj, err := Encode(map[string]string{
 		"key1": "val1",
 		"key2": "val2",
 		"key3": "val3",
@@ -40,11 +40,11 @@ representation with `obj.RawData()`.
 
 Objects can be linked by assigning an object's CID as the value of a property:
 
-	jane := MustEncode(Properties{"name": "Jane"})
-	john := MustEncode(Properties{"name": "John"})
-	jack := MustEncode(Properties{"name": "Jack"})
+	jane := MustEncode(map[string]string{"name": "Jane"})
+	john := MustEncode(map[string]string{"name": "John"})
+	jack := MustEncode(map[string]string{"name": "Jack"})
 
-	me := MustEncode(Properties{
+	me := MustEncode(map[string]string{
 		"sister": jane.Cid(),
 		"children": []*cid.Cid{
 			john.Cid(),

--- a/meta.go
+++ b/meta.go
@@ -29,10 +29,6 @@ import (
 	"github.com/ipfs/go-ipld-format"
 )
 
-// Properties represent the key-value pairs which make up a META objects
-// properties.
-type Properties map[string]interface{}
-
 // Object is a META object which uses IPLD DAG CBOR as the byte representation,
 // and IPLD CID as the object identifier.
 type Object struct {


### PR DESCRIPTION
This change drops the `Properties` type and updates the `Encode` method so that it supports encoding arbitrary types. It also adds `Object.Decode` so a META object can be decoded into a Go type.