### PR TITLE
CWR: encode files with ISO-88591-1

### DIFF
--- a/cwr/README.md
+++ b/cwr/README.md
@@ -56,7 +56,7 @@ You can then query the index with the `sqlite3` CLI and dump the resulting
 META objects using `meta dump`, for example searching for "PUNK CLUB":
 
 ```
-$ sqlite3 registeredwork.db "SELECT object_id FROM artist WHERE title = 'PUNK CLUB'"
+$ sqlite3 registeredwork.db "SELECT object_id FROM registered_work WHERE title = 'PUNK CLUB'"
 zdpuAoVMEcareeS4TXPr7YAYNztY1ybbvobV8t7XMkzS9rMeq
 
 $ meta dump zdpuAoVMEcareeS4TXPr7YAYNztY1ybbvobV8t7XMkzS9rMeq/iswc

--- a/cwr/parser.go
+++ b/cwr/parser.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 )
 
@@ -31,6 +32,9 @@ import (
 func ParseCWRFile(cwrFileReader io.Reader, CWRDataApiPath string) (registeredWorks []*RegisteredWork, err error) {
 	//phase 1 : Transform cwr formatted file to cwr-json file using CWR-DataApi python script.
 	cmd := exec.Command("python3", CWRDataApiPath+"/cwr2json.py")
+	cmd.Env = append(os.Environ(),
+		"PYTHONIOENCODING=ISO-8859-1",
+	)
 	cmd.Stdin = cwrFileReader
 
 	var stdout, stderr bytes.Buffer

--- a/cwr/parser.go
+++ b/cwr/parser.go
@@ -32,6 +32,8 @@ import (
 func ParseCWRFile(cwrFileReader io.Reader, CWRDataApiPath string) (registeredWorks []*RegisteredWork, err error) {
 	//phase 1 : Transform cwr formatted file to cwr-json file using CWR-DataApi python script.
 	cmd := exec.Command("python3", CWRDataApiPath+"/cwr2json.py")
+	//Use explicit encoding because it seems like some of the CWR files are ISO-8859-1 encoded
+	//and include characters which fail under UTF-8 (python default encoder) encoding due to lack or invalid continuation byte.
 	cmd.Env = append(os.Environ(),
 		"PYTHONIOENCODING=ISO-8859-1",
 	)


### PR DESCRIPTION
- Set pythonencoding to ISO-88591-1
- Update git submodule  :
         -fast read stdin.
         -add cwr grammar flexibility. 
         -support COM record type.
- Update readme 
