### PR TITLE
identity: Add a HTTP API to create and manage identities

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/meta-network/go-meta/cwr"
 	"github.com/meta-network/go-meta/eidr"
 	"github.com/meta-network/go-meta/ern"
+	"github.com/meta-network/go-meta/identity"
 	"github.com/meta-network/go-meta/musicbrainz"
 	"github.com/meta-network/go-meta/xml"
 )
@@ -48,6 +49,12 @@ func NewServer(store *meta.Store, musicbrainzDB *sql.DB, cwrDB *sql.DB, ernDB *s
 	}
 	srv.router.GET("/object/:cid", srv.HandleGetObject)
 	srv.router.POST("/import/xml", srv.HandleImportXML)
+
+	// add the identity API at /meta-id
+	identityAPI := identity.NewAPI(identity.NewMemoryStore())
+	srv.router.Handler("GET", "/meta-id/*path", http.StripPrefix("/meta-id", identityAPI))
+	srv.router.Handler("POST", "/meta-id/*path", http.StripPrefix("/meta-id", identityAPI))
+
 	if musicbrainzDB != nil {
 		musicbrainzApi, err := musicbrainz.NewAPI(musicbrainzDB, store)
 		if err != nil {

--- a/identity/api.go
+++ b/identity/api.go
@@ -1,0 +1,105 @@
+// This file is part of the go-meta library.
+//
+// Copyright (C) 2017 JAAK MUSIC LTD
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// If you have any questions please contact yo@jaak.io
+
+package identity
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// API is a HTTP API to create and update META identities.
+type API struct {
+	store  Store
+	router *httprouter.Router
+}
+
+// NewAPI returns a new API which uses the given store to load and save
+// identities.
+func NewAPI(store Store) *API {
+	api := &API{
+		store:  store,
+		router: httprouter.New(),
+	}
+	api.router.POST("/", api.handleCreateIdentity)
+	api.router.GET("/:name", api.handleGetIdentity)
+	api.router.POST("/:name", api.handleUpdateIdentity)
+	return api
+}
+
+// ServeHTTP implements the http.Handler interface so that the API can be used
+// to serve HTTP requests.
+func (a *API) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	a.router.ServeHTTP(w, req)
+}
+
+func (a *API) handleCreateIdentity(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	name := req.FormValue("name")
+	if name == "" {
+		http.Error(w, "missing name parameter", http.StatusBadRequest)
+		return
+	}
+	identity := NewIdentity(name)
+	if err := a.store.Save(identity); err != nil {
+		http.Error(w, fmt.Sprintf("error saving identity: %s", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application./json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(identity)
+}
+
+func (a *API) handleGetIdentity(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	name := p.ByName("name")
+	identity, err := a.store.Load(name)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error loading identity: %s", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application./json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(identity)
+}
+
+func (a *API) handleUpdateIdentity(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	var aux map[string]string
+	if err := json.NewDecoder(req.Body).Decode(&aux); err != nil {
+		http.Error(w, fmt.Sprintf("error reading aux from request: %s", err), http.StatusBadRequest)
+		return
+	}
+	name := p.ByName("name")
+	identity, err := a.store.Load(name)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error loading identity: %s", err), http.StatusInternalServerError)
+		return
+	}
+	for key, val := range aux {
+		identity.Aux[key] = val
+	}
+	if err := a.store.Save(identity); err != nil {
+		http.Error(w, fmt.Sprintf("error saving identity: %s", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application./json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(identity)
+}

--- a/identity/api_test.go
+++ b/identity/api_test.go
@@ -1,0 +1,67 @@
+// This file is part of the go-meta library.
+//
+// Copyright (C) 2017 JAAK MUSIC LTD
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// If you have any questions please contact yo@jaak.io
+
+package identity
+
+import (
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+// TestAPI tests creating and updating identities via the API.
+func TestAPI(t *testing.T) {
+	// start the identity API
+	store := NewMemoryStore()
+	api := NewAPI(store)
+	srv := httptest.NewServer(api)
+	defer srv.Close()
+
+	// create an identity
+	client := NewClient(srv.URL)
+	name := "lmars"
+	identity, err := client.CreateIdentity(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check the identity can be loaded from the API
+	gotIdentity, err := client.GetIdentity(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotIdentity.Name != identity.Name {
+		t.Fatalf("expected identity to have name %q, got %q", identity.Name, gotIdentity.Name)
+	}
+
+	// update the identity
+	updates := map[string]string{"foo": "bar"}
+	if _, err := client.UpdateIdentity(name, updates); err != nil {
+		t.Fatal(err)
+	}
+
+	// check that the updated identity can be loaded from the API
+	gotIdentity, err = client.GetIdentity(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotIdentity.Aux, updates) {
+		t.Fatalf("expected identity to have aux %v, got %v", updates, gotIdentity.Aux)
+	}
+}

--- a/identity/client.go
+++ b/identity/client.go
@@ -1,0 +1,94 @@
+// This file is part of the go-meta library.
+//
+// Copyright (C) 2017 JAAK MUSIC LTD
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// If you have any questions please contact yo@jaak.io
+
+package identity
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+type Client struct {
+	baseURL string
+}
+
+func NewClient(baseURL string) *Client {
+	return &Client{baseURL}
+}
+
+func (c *Client) CreateIdentity(name string) (*Identity, error) {
+	form := make(url.Values)
+	form.Set("name", name)
+	res, err := http.PostForm(c.baseURL, form)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(res.Body)
+		return nil, fmt.Errorf("unexpected HTTP response: %s: %s", res.Status, body)
+	}
+	var identity Identity
+	if err := json.NewDecoder(res.Body).Decode(&identity); err != nil {
+		return nil, err
+	}
+	return &identity, nil
+}
+
+func (c *Client) GetIdentity(name string) (*Identity, error) {
+	res, err := http.Get(c.baseURL + "/" + name)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(res.Body)
+		return nil, fmt.Errorf("unexpected HTTP response: %s: %s", res.Status, body)
+	}
+	var identity Identity
+	if err := json.NewDecoder(res.Body).Decode(&identity); err != nil {
+		return nil, err
+	}
+	return &identity, nil
+}
+
+func (c *Client) UpdateIdentity(name string, aux map[string]string) (*Identity, error) {
+	data, err := json.Marshal(aux)
+	if err != nil {
+		return nil, err
+	}
+	res, err := http.Post(c.baseURL+"/"+name, "application/json", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(res.Body)
+		return nil, fmt.Errorf("unexpected HTTP response: %s: %s", res.Status, body)
+	}
+	var identity Identity
+	if err := json.NewDecoder(res.Body).Decode(&identity); err != nil {
+		return nil, err
+	}
+	return &identity, nil
+}

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -1,0 +1,39 @@
+// This file is part of the go-meta library.
+//
+// Copyright (C) 2017 JAAK MUSIC LTD
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// If you have any questions please contact yo@jaak.io
+
+package identity
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type Identity struct {
+	Name string            `json:"name"`
+	ID   common.Hash       `json:"id"`
+	Aux  map[string]string `json:"aux"`
+}
+
+func NewIdentity(name string) *Identity {
+	return &Identity{
+		Name: name,
+		ID:   crypto.Keccak256Hash([]byte(name)),
+		Aux:  make(map[string]string),
+	}
+}

--- a/identity/store.go
+++ b/identity/store.go
@@ -1,0 +1,58 @@
+// This file is part of the go-meta library.
+//
+// Copyright (C) 2017 JAAK MUSIC LTD
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// If you have any questions please contact yo@jaak.io
+
+package identity
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Store interface {
+	Load(name string) (*Identity, error)
+	Save(*Identity) error
+}
+
+type MemoryStore struct {
+	mtx        sync.RWMutex
+	identities map[string]*Identity
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		identities: make(map[string]*Identity),
+	}
+}
+
+func (m *MemoryStore) Load(name string) (*Identity, error) {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	i, ok := m.identities[name]
+	if !ok {
+		return nil, fmt.Errorf("identity not found: %s", name)
+	}
+	return i, nil
+}
+
+func (m *MemoryStore) Save(identity *Identity) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.identities[identity.Name] = identity
+	return nil
+}


### PR DESCRIPTION
The API:

* `POST /meta-id/?name=<name>` - create a META Identity using `name`
* `GET /meta-id/<name>` - get the details of META Identity `name`
* `POST /meta-id/<name>` - update the aux details for the META Identity (pass a JSON encoded object as the body)

The implementation currently just stores the identities in memory, a future PR will save them in a deployed identity contract.

Example usage:

```
$ curl -X POST http://localhost:5000/meta-id/?name=lmars                                                                                                                     
{"name":"lmars","id":"0xac489887d8a3743ad1178a51e3035036e78bf902118bb20e46d8dc8e3349bf19","aux":{}}

$ curl http://localhost:5000/meta-id/lmars                                                                                                                                   
{"name":"lmars","id":"0xac489887d8a3743ad1178a51e3035036e78bf902118bb20e46d8dc8e3349bf19","aux":{}}

$ curl -X POST --data-binary '{"foo": "bar"}' http://localhost:5000/meta-id/lmars
{"name":"lmars","id":"0xac489887d8a3743ad1178a51e3035036e78bf902118bb20e46d8dc8e3349bf19","aux":{"foo":"bar"}}

$ curl http://localhost:5000/meta-id/lmars
{"name":"lmars","id":"0xac489887d8a3743ad1178a51e3035036e78bf902118bb20e46d8dc8e3349bf19","aux":{"foo":"bar"}}
```