### PR TITLE
misc: Add graphQL schema types for music domain ontologies

### DIFF
--- a/media.graphql
+++ b/media.graphql
@@ -21,6 +21,7 @@
 # ISWC - International Standard Musical Work Code
 # GRid - Global Release Identifier
 # UPC  - Universal Product Code
+# EAN  - International Article Number
 #
 # Other entity properties (like performer name or recording title) are linked
 # to these identifiers by various sources in the META network.
@@ -102,7 +103,8 @@ type MusicRelease {
 }
 
 type MusicProduct {
-  upc: ID
+  upc: StringValue
+  ean: StringValue
 
   releases:   [MusicReleaseLink]
   recordings: [MusicRecordingLink]

--- a/media.graphql
+++ b/media.graphql
@@ -70,7 +70,7 @@ type MusicPublisher {
 }
 
 type MusicRecording {
-  isrc: ID
+  isrc: StringValue
 
   title: StringValue
 
@@ -82,7 +82,7 @@ type MusicRecording {
 }
 
 type MusicWork {
-  iswc: ID
+  iswc: StringValue
 
   title: StringValue
 
@@ -92,7 +92,7 @@ type MusicWork {
 }
 
 type MusicRelease {
-  grid: ID
+  grid: StringValue
 
   title: StringValue
 

--- a/media.graphql
+++ b/media.graphql
@@ -1,0 +1,185 @@
+# This GraphQL schema defines the META Media types and queries.
+#
+# It consists of the following main entities:
+#
+# MusicPerformer
+# MusicComposer
+# RecordLabel
+# MusicPublisher
+# MusicRecording
+# MusicWork
+# MusicRelease
+# MusicProduct
+#
+# Each entity has a set of widely used identifiers which are used to uniquely
+# identify them:
+#
+# ISNI - International Standard Name Identifier
+# IPI  - Interested Parties Information
+# DPID - DDEX Party Identifier
+# ISRC - International Standard Recording Code
+# ISWC - International Standard Musical Work Code
+# GRid - Global Release Identifier
+# UPC  - Universal Product Code
+#
+# Other entity properties (like performer name or recording title) are linked
+# to these identifiers by various sources in the META network.
+
+#
+# --- Main Entities ---
+#
+type MusicPerformer {
+  identifiers: [PartyIdentifier]
+
+  name: StringValue
+
+  products:   [MusicProductLink]
+  releases:   [MusicReleaseLink]
+  recordings: [MusicRecordingLink]
+  labels:     [RecordLabelLink]
+}
+
+type MusicComposer {
+  identifiers: [PartyIdentifier]
+
+  name: StringValue
+
+  works:      [MusicWorkLink]
+  publishers: [MusicPublisherLink]
+}
+
+type RecordLabel {
+  identifiers: [PartyIdentifier]
+
+  name: StringValue
+
+  products:   [MusicProductLink]
+  releases:   [MusicReleaseLink]
+  recordings: [MusicRecordingLink]
+  performers: [MusicPerformerLink]
+}
+
+type MusicPublisher {
+  identifiers: [PartyIdentifier]
+
+  name: StringValue
+
+  composers: [MusicComposerLink]
+  works:     [MusicWorkLink]
+}
+
+type MusicRecording {
+  isrc: ID
+
+  title: StringValue
+
+  products:   [MusicProductLink]
+  releases:   [MusicReleaseLink]
+  performers: [MusicPerformerLink]
+  labels:     [RecordLabelLink]
+  works:      [MusicWorkLink]
+}
+
+type MusicWork {
+  iswc: ID
+
+  title: StringValue
+
+  composers:  [MusicComposerLink]
+  recordings: [MusicRecordingLink]
+  publishers: [MusicPublisherLink]
+}
+
+type MusicRelease {
+  grid: ID
+
+  title: StringValue
+
+  products:   [MusicProductLink]
+  recordings: [MusicRecordingLink]
+  performers: [MusicPerformerLink]
+  labels:     [RecordLabelLink]
+}
+
+type MusicProduct {
+  upc: ID
+
+  releases:   [MusicReleaseLink]
+  recordings: [MusicRecordingLink]
+  performers: [MusicPerformerLink]
+  labels:     [RecordLabelLink]
+}
+
+#
+# --- Link Types ---
+#
+type MusicPerformerLink {
+  source:    Source!
+  performer: MusicPerformer!
+  role:      String
+}
+
+type MusicComposerLink {
+  source:   Source!
+  composer: MusicComposer!
+}
+
+type RecordLabelLink {
+  source: Source!
+  label:  RecordLabel!
+}
+
+type MusicPublisherLink {
+  source:    Source!
+  publisher: MusicPublisher!
+}
+
+type MusicRecordingLink {
+  source:    Source!
+  recording: MusicRecording!
+}
+
+type MusicWorkLink {
+  source: Source!
+  work:   MusicWork!
+}
+
+type MusicReleaseLink {
+  source:  Source!
+  release: MusicRelease!
+}
+
+type MusicProductLink {
+  source:  Source!
+  product: MusicProduct!
+}
+
+#
+# --- Value Types ---
+#
+enum PartyIdentifierType {
+  ISNI
+  IPI
+  DPID
+}
+
+type PartyIdentifier {
+  type:   PartyIdentifierType!
+  value:  String!
+  source: Source!
+}
+
+type StringValue {
+  value:   String!
+  sources: [StringSource]
+}
+
+type StringSource {
+  value:  String!
+  source: Source!
+  score:  Int!
+}
+
+type Source {
+  name: String!
+}

--- a/meta-schema.graphql
+++ b/meta-schema.graphql
@@ -1,30 +1,31 @@
 # Base types
-type Party {
+type Identifiers {
 	id:ID!
-	idType:String! #PartyId, IPI, ISNI, MBID
-	displayName:String!
-	firstName: String
-	lastName: String
+	idType:String! # IPI || ISWC || GRid
 }
 
-type Organisation {
-	id:String!
-	idType:String! #DPid, IPI, MBID
+type Party {
+	identifiers:[Identifiers]!
 	displayName:String!
 	formalName:String
+	firstName: String
+	lastName: String
+	role:String
+	works:[MusicWork]
+	recordings:[MusicRecording]
+	products:[MusicProduct]
 }
 
 # Music Types
 type TerritoryAgreement {
-	territoryCode:Int! #CISAC Territory standard
-	condition:String! # CWR inclusion/exclusion indicator
+	territoryCode:String! # String to handle CISAC Territory standard || ISO
+	condition:String! # inclusion/exclusion indicator
 }
 
-type InterestedPartyAgreement {
+type interestedPartyAgreement {
 	agreementRoleCode:String!
 	interestedPartyNumber:Int!
-	ipi:Int
-	ipiBase:Int
+	identifiers:[Identifiers]!
 	lastName:String!
 	firstName:String
 	prSociety:String
@@ -34,42 +35,37 @@ type InterestedPartyAgreement {
 }
 
 type MusicWork {
-	iswc:String
+	identifiers:[Identifiers]!
 	workTitle:String!
 	territories:[TerritoryAgreement]
-	interestedParty:[InterestedPartyAgreement]
-	publishers:[Organisation]
+	interestedParties:[interestedPartyAgreement]
+	publishers:[Party]
 	composers:[MusicComposer]
 	recordings:[MusicRecording]
 }
 
-# DDEX:ERN:SoundRecording
 type MusicRecording {
-	isrc: String
-	iswc: String
+	identifiers:[Identifiers]!
 	displayTitle:String!
-	displayArtist:String!
+	displayArtist:[Party!]!
 	contributors:[Party]
-	label:[Organisation]
+	label:[Party]
 	genre:String
 	work:MusicWork
 	products:[MusicProduct]
 }
 
 type TerritoryProduct {
-	territoryCode:String!
+	territories:[TerritoryAgreement]
 	releaseDate:String!
 	displayTitle:String!
 	displayArtist:String
-	label:[Organisation]
+	label:[Party]
 	genre:String
 }
 
-# DDEX:ERN:Release
 type MusicProduct {
-	grid:String!
-	isrc: String
-	iswc: String
+	identifiers:[Identifiers]!
 	productType:String!
 	displayTitle:String!
 	genre:String
@@ -77,39 +73,19 @@ type MusicProduct {
 	territoryProducts:[TerritoryProduct]!
 }
 
-type MusicPerformer {
-	isni: String
-	displayName:String!
-	firstName: String
-	lastName: String
-	recordings:[MusicRecording]
-	products:[MusicProduct]
-}
-
-type MusicComposer {
-	ipi:Int
-	ipiBase:Int
-	displayName:String!
-	firstName: String
-	lastName: String
-	works:[MusicWork]
-}
-
 type RecordLabel {
-	id:String!
-	idType:String #DPid, IPI, MBID
+	identifiers:[Identifiers!]!
 	displayName:String!
 	formalName:String
-	performers:[MusicPerformer]
+	performers:[Party]
 	recordings:[MusicRecording]
 	products:[MusicProduct]
 }
 
 type MusicPublisher {
-	id:String!
-	idType:String #DPid, IPI, MBID
+	identifiers:[Identifiers!]!
 	displayName:String!
 	formalName:String
-	composers:[MusicComposer]
+	composers:[Party]
 	works:[MusicWork]
 }

--- a/meta-schema.graphql
+++ b/meta-schema.graphql
@@ -6,28 +6,23 @@ type Identifiers {
 
 type Party {
 	identifiers:[Identifiers]!
+	type:String! # Person || Organisation
 	displayName:String!
 	formalName:String
 	firstName: String
 	lastName: String
-	role:String
-	works:[MusicWork]
-	recordings:[MusicRecording]
-	products:[MusicProduct]
 }
 
 # Music Types
 type TerritoryAgreement {
-	territoryCode:String! # String to handle CISAC Territory standard || ISO
+	isoTerritoryCode:String!
 	condition:String! # inclusion/exclusion indicator
 }
 
 type interestedPartyAgreement {
 	agreementRoleCode:String!
 	interestedPartyNumber:Int!
-	identifiers:[Identifiers]!
-	lastName:String!
-	firstName:String
+	party:Party
 	prSociety:String
 	prShare:Int
 	mrSociety:String
@@ -40,14 +35,14 @@ type MusicWork {
 	territories:[TerritoryAgreement]
 	interestedParties:[interestedPartyAgreement]
 	publishers:[Party]
-	composers:[MusicComposer]
+	composers:[Composer]
 	recordings:[MusicRecording]
 }
 
 type MusicRecording {
 	identifiers:[Identifiers]!
 	displayTitle:String!
-	displayArtist:[Party!]!
+	displayArtist:[Performer!]!
 	contributors:[Party]
 	label:[Party]
 	genre:String
@@ -73,19 +68,27 @@ type MusicProduct {
 	territoryProducts:[TerritoryProduct]!
 }
 
+type Performer {
+	party:Party!
+	role:String
+	recordings:[MusicRecording]
+	products:[MusicProduct]
+}
+
+type Composer {
+	party:Party
+	works:[MusicWork]
+}
+
 type RecordLabel {
-	identifiers:[Identifiers!]!
-	displayName:String!
-	formalName:String
-	performers:[Party]
+	party:Party
+	performers:[Performer]
 	recordings:[MusicRecording]
 	products:[MusicProduct]
 }
 
 type MusicPublisher {
-	identifiers:[Identifiers!]!
-	displayName:String!
-	formalName:String
-	composers:[Party]
+	party:Party
+	composers:[Composer]
 	works:[MusicWork]
 }

--- a/meta-schema.graphql
+++ b/meta-schema.graphql
@@ -1,0 +1,115 @@
+# Base types
+type Party {
+	id:ID!
+	idType:String! #PartyId, IPI, ISNI, MBID
+	displayName:String!
+	firstName: String
+	lastName: String
+}
+
+type Organisation {
+	id:String!
+	idType:String! #DPid, IPI, MBID
+	displayName:String!
+	formalName:String
+}
+
+# Music Types
+type TerritoryAgreement {
+	territoryCode:Int! #CISAC Territory standard
+	condition:String! # CWR inclusion/exclusion indicator
+}
+
+type InterestedPartyAgreement {
+	agreementRoleCode:String!
+	interestedPartyNumber:Int!
+	ipi:Int
+	ipiBase:Int
+	lastName:String!
+	firstName:String
+	prSociety:String
+	prShare:Int
+	mrSociety:String
+	mrShare:Int
+}
+
+type MusicWork {
+	iswc:String
+	workTitle:String!
+	territories:[TerritoryAgreement]
+	interestedParty:[InterestedPartyAgreement]
+	publishers:[Organisation]
+	composers:[MusicComposer]
+	recordings:[MusicRecording]
+}
+
+# DDEX:ERN:SoundRecording
+type MusicRecording {
+	isrc: String
+	iswc: String
+	displayTitle:String!
+	displayArtist:String!
+	contributors:[Party]
+	label:[Organisation]
+	genre:String
+	work:MusicWork
+	products:[MusicProduct]
+}
+
+type TerritoryProduct {
+	territoryCode:String!
+	releaseDate:String!
+	displayTitle:String!
+	displayArtist:String
+	label:[Organisation]
+	genre:String
+}
+
+# DDEX:ERN:Release
+type MusicProduct {
+	grid:String!
+	isrc: String
+	iswc: String
+	productType:String!
+	displayTitle:String!
+	genre:String
+	recordings:[MusicRecording]
+	territoryProducts:[TerritoryProduct]!
+}
+
+type MusicPerformer {
+	isni: String
+	displayName:String!
+	firstName: String
+	lastName: String
+	recordings:[MusicRecording]
+	products:[MusicProduct]
+}
+
+type MusicComposer {
+	ipi:Int
+	ipiBase:Int
+	displayName:String!
+	firstName: String
+	lastName: String
+	works:[MusicWork]
+}
+
+type RecordLabel {
+	id:String!
+	idType:String #DPid, IPI, MBID
+	displayName:String!
+	formalName:String
+	performers:[MusicPerformer]
+	recordings:[MusicRecording]
+	products:[MusicProduct]
+}
+
+type MusicPublisher {
+	id:String!
+	idType:String #DPid, IPI, MBID
+	displayName:String!
+	formalName:String
+	composers:[MusicComposer]
+	works:[MusicWork]
+}


### PR DESCRIPTION
This PR proposes the graphQL schema for the current domain ontologies currently in scope: ERN, CWR & MusicBrainz. The longer term intention is for these types to formulate the basis for the top ontology of META.
The limited field coverage will suffice for now as a viable implementation for testing.
The semantics will need to be improved when the scope is increased from music only, mostly to avoid repetition.

The below types are what will be used for querying based on META ID:
- MusicPerformer
- MusicComposer
- RecordLabel
- MusicPublisher


I was unsure where to put the file, as discussed in slack, so i chucked it in at root. 