### PR TITLE
meta: Add '@source' property to all META objects

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -38,8 +38,8 @@ import (
 	"github.com/meta-network/go-meta"
 )
 
-// TestCWRCommands tests running the 'meta cwr convert' and
-// 'meta cwr index' commands.
+// TestCWRCommands tests running the 'meta convert cwr' and
+// 'meta index cwr' commands.
 func TestCWRCommands(t *testing.T) {
 	c, err := newTestCLI(t)
 	if err != nil {
@@ -48,8 +48,9 @@ func TestCWRCommands(t *testing.T) {
 	defer os.RemoveAll(c.tmpDir)
 	defer c.srv.Close()
 
-	// check 'meta cwr convert' prints a CID
-	stdout := c.run("cwr", "convert",
+	// check 'meta convert cwr' prints a CID
+	stdout := c.run("convert", "cwr",
+		"--source", "test",
 		"../cwr/testdata/example_double_nwr.cwr",
 		"../cwr/testdata/example_nwr.cwr")
 	var ids []string
@@ -62,8 +63,8 @@ func TestCWRCommands(t *testing.T) {
 		ids = append(ids, id.String())
 	}
 	expected := []string{
-		"zdqaWGBExvi5qtMnW2JNMGjMdHvbFcJJxWbzSYRZTAjWoApCm",
-		"zdqaWPCaSDCmG664Rqka633WYVEKUcgQoetK6ZeuxTpw1Y5bJ",
+		"zdqaWBuxwxhZQj9PBzRsHSp2WEq9pF3tF9rP9KYb7TxgqfXQJ",
+		"zdqaWGLaDAkMomHFaooZ7GaxxvTmFCJ1DFCVLaQSvb8v2ewoN",
 	}
 	if !reflect.DeepEqual(ids, expected) {
 		t.Fatalf("unexpected CIDs:\nexpected: %v\ngot:      %v", expected, ids)
@@ -71,9 +72,9 @@ func TestCWRCommands(t *testing.T) {
 
 	db := filepath.Join(c.tmpDir, "index.db")
 
-	// run 'meta cwr index' with the CIDs as stdin
+	// run 'meta index cwr' with the CIDs as stdin
 	stream := strings.NewReader(stdout)
-	c.runWithStdin(stream, "cwr", "index", db)
+	c.runWithStdin(stream, "index", "cwr", db)
 
 	// check the index was populated
 	cmd := exec.Command("sqlite3", db, "SELECT cwr_id FROM transmission_header ORDER BY cwr_id")
@@ -88,8 +89,8 @@ func TestCWRCommands(t *testing.T) {
 	}
 }
 
-// TestERNCommands tests running the 'meta ern convert' and
-// 'meta ern index' commands.
+// TestERNCommands tests running the 'meta convert ern' and
+// 'meta index ern' commands.
 func TestERNCommands(t *testing.T) {
 	c, err := newTestCLI(t)
 	if err != nil {
@@ -98,8 +99,9 @@ func TestERNCommands(t *testing.T) {
 	defer os.RemoveAll(c.tmpDir)
 	defer c.srv.Close()
 
-	// check 'meta ern convert' prints multiple CIDs
-	stdout := c.run("ern", "convert",
+	// check 'meta convert ern' prints multiple CIDs
+	stdout := c.run("convert", "ern",
+		"--source", "test",
 		"../ern/testdata/Profile_AudioAlbumMusicOnly.xml",
 		"../ern/testdata/Profile_AudioAlbum_WithBooklet.xml",
 		"../ern/testdata/Profile_AudioBook.xml",
@@ -116,11 +118,11 @@ func TestERNCommands(t *testing.T) {
 		ids = append(ids, id.String())
 	}
 	expected := []string{
-		"zdqaWFZus1xdS6ehSsMsVDjAj5VbmRoXjVSArNQCo83t4ZfPL",
-		"zdqaWLQKmXULssLQurdExgi4Qtj6eUYC9ZXWMDG9LUZuQkGX2",
-		"zdqaWBmEzYHUkKvFs8WsYqBv4RnUS9uK4JLgsSxDPFh98dnhq",
-		"zdqaWJ6kzSuv1q4XAciSeqvEBdnbv5jhxGh33vgYPzjn8vJ1h",
-		"zdqaWHDqp7MX7uFqrjB15D7F8QnXfgV5EoFAeCyo3pUe7qWMS",
+		"zdqaWQFfLpAj7Hi7B1DMsqfRzh2gtTWJb6PKzK2TJZgb3gCEM",
+		"zdqaWJ4jkU4haHkCfJY8Tz7bNtdi38Kq1bRy4iiU9DUDJqUkB",
+		"zdqaWRL5oXkGnwhf9JWzgMdV7H1YUWp6YociP5aWB9EU6qAJr",
+		"zdqaWSBmxw7xif1hx4ZXVyC6A6Fr6hcx34JLuf9BGDT7P7utp",
+		"zdqaWBoE9GfAc1dsJgW1jqtbHYKHgLcFfw55SKDyxEEGcQWso",
 	}
 	if !reflect.DeepEqual(ids, expected) {
 		t.Fatalf("unexpected CIDs:\nexpected: %v\ngot:      %v", expected, ids)
@@ -128,9 +130,9 @@ func TestERNCommands(t *testing.T) {
 
 	db := filepath.Join(c.tmpDir, "index.db")
 
-	// run 'meta ern index' with the CIDs as stdin
+	// run 'meta index ern' with the CIDs as stdin
 	stream := strings.NewReader(stdout)
-	c.runWithStdin(stream, "ern", "index", db)
+	c.runWithStdin(stream, "index", "ern", db)
 
 	// check the index was populated
 	cmd := exec.Command("sqlite3", db, "SELECT cid FROM ern ORDER BY cid")
@@ -145,16 +147,17 @@ func TestERNCommands(t *testing.T) {
 	}
 }
 
-// TestERNCommands tests running the 'meta eidr convert' and
-// 'meta eidr index' commands.
+// TestERNCommands tests running the 'meta convert eidr' and
+// 'meta index eidr' commands.
 func TestEIDRCommands(t *testing.T) {
 	c, err := newTestCLI(t)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// check 'meta eidr convert' outputs expected rows
-	stdout := c.run("eidr", "convert",
+	// check 'meta convert eidr' outputs expected rows
+	stdout := c.run("convert", "eidr",
+		"--source", "test",
 		"../eidr/testdata/dummy_child.xml",
 		"../eidr/testdata/dummy_parent.xml",
 	)
@@ -168,8 +171,8 @@ func TestEIDRCommands(t *testing.T) {
 		ids = append(ids, id.String())
 	}
 	expected := []string{
-		"zdqaWJPALP7hJvSNbwQ7i6dYLbvtfXtWCFNZiSgwJCjgFzbkB",
-		"zdqaWN1MA87hZJC7LggR6wKZtVCcLURRjzVZDDgQzZJZR5a2F",
+		"zdqaWUgTjLPoFrMCmBcbPcJNPuHTvUs5fBn3f4iYsniHACo7q",
+		"zdqaWTaGbQFm2HEYo2iwHsFanffKDYq49XVk5ggEc6dYaBQkv",
 	}
 	if !reflect.DeepEqual(ids, expected) {
 		t.Fatalf("unexpected CIDs:\nexpected: %v\ngot:      %v", expected, ids)
@@ -183,9 +186,9 @@ func TestEIDRCommands(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	db := filepath.Join(tmpDir, "index.db")
 
-	// run 'meta ern index' with the CIDs as stdin
+	// run 'meta index eidr' with the CIDs as stdin
 	stream := strings.NewReader(stdout)
-	c.runWithStdin(stream, "eidr", "index", db)
+	c.runWithStdin(stream, "index", "eidr", db)
 
 	// check if the index has the baseobject and xobject
 	cmd := exec.Command("sqlite3", db, "select count(*) from xobject_baseobject_link x inner join baseobject p, xobject_episode e on p.doi_id = x.parent_doi_id where e.id = x.xobject_id")

--- a/cwr/index_test.go
+++ b/cwr/index_test.go
@@ -220,7 +220,7 @@ func newTestIndex() (x *testIndex, err error) {
 	}
 	defer f.Close()
 
-	x.cwrCid, err = converter.ConvertCWR(f)
+	x.cwrCid, err = converter.ConvertCWR(f, "test")
 	if err != nil {
 		return nil, err
 	}

--- a/cwr/types.go
+++ b/cwr/types.go
@@ -19,6 +19,8 @@
 
 package cwr
 
+import "github.com/meta-network/go-meta"
+
 // RegisteredWork represents a CWR work registratin , see
 // see http://musicmark.com/documents/cwr11-1494_cwr_user_manual_2011-09-23_e_2011-09-23_en.pdf
 // NWR or REV record
@@ -124,6 +126,8 @@ type WriterControlledbySubmitter struct {
 
 // Record - include all CWR records fields
 type Record struct {
+	meta.BaseObject
+
 	RecordType                     string `json:"record_type,omitempty"`
 	TransactionSequenceN           string `json:"transactionSequenceN,omitempty"`
 	RecordSequenceN                string `json:"recordSequenceN,omitempty"`

--- a/eidr/convert.go
+++ b/eidr/convert.go
@@ -28,25 +28,23 @@ import (
 	"github.com/meta-network/go-meta/xmlschema"
 )
 
-// Converter converts DDEX ERN XML files into META objects.
+// Converter converts EIDR XML files into META objects.
 type Converter struct {
-	store *meta.Store
+	*metaxml.Converter
 }
 
 // NewConverter returns a Converter which stores META objects in the given META
 // store.
 func NewConverter(store *meta.Store) *Converter {
-	return &Converter{
-		store: store,
-	}
+	return &Converter{metaxml.NewConverter(store)}
 }
 
-func (c *Converter) ConvertEIDRXML(src io.Reader) (*cid.Cid, error) {
+func (c *Converter) ConvertEIDRXML(xml io.Reader, source string) (*cid.Cid, error) {
 	context := []*cid.Cid{
 		xmlschema.EIDR_common.Cid,
 		xmlschema.EIDR_md.Cid,
 	}
-	obj, err := metaxml.EncodeXML(src, context, c.store.Put)
+	obj, err := c.ConvertXML(xml, context, source)
 	if err != nil {
 		return nil, err
 	}

--- a/ern/convert.go
+++ b/ern/convert.go
@@ -30,26 +30,24 @@ import (
 
 // Converter converts DDEX ERN XML files into META objects.
 type Converter struct {
-	store *meta.Store
+	*metaxml.Converter
 }
 
 // NewConverter returns a Converter which stores META objects in the given META
 // store.
 func NewConverter(store *meta.Store) *Converter {
-	return &Converter{
-		store: store,
-	}
+	return &Converter{metaxml.NewConverter(store)}
 }
 
-// ConvertERN converts the given source XML file into a META object graph and
-// returns the CID of the graph's root META object.
-func (c *Converter) ConvertERN(src io.Reader) (*cid.Cid, error) {
+// ConvertERN converts the given ERN XML file into a META object graph with the
+// given source and returns the CID of the graph's root META object.
+func (c *Converter) ConvertERN(xml io.Reader, source string) (*cid.Cid, error) {
 	// use the DDEX ERN/382 and AVS XML schemas as the JSON-LD context
 	context := []*cid.Cid{
 		xmlschema.DDEX_Ern382.Cid,
 		xmlschema.DDEX_Avs.Cid,
 	}
-	obj, err := metaxml.EncodeXML(src, context, c.store.Put)
+	obj, err := c.ConvertXML(xml, context, source)
 	if err != nil {
 		return nil, err
 	}

--- a/ern/index_test.go
+++ b/ern/index_test.go
@@ -50,7 +50,7 @@ func TestIndex(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer f.Close()
-		cid, err := converter.ConvertERN(f)
+		cid, err := converter.ConvertERN(f, "test")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/meta.go
+++ b/meta.go
@@ -30,6 +30,11 @@ import (
 	multihash "github.com/multiformats/go-multihash"
 )
 
+// BaseObject contains the fields that all META objects should have.
+type BaseObject struct {
+	Source string `json:"@source"`
+}
+
 // Object is a META object which uses IPLD DAG CBOR as the byte representation,
 // and IPLD CID as the object identifier.
 type Object struct {

--- a/musicbrainz/convert.go
+++ b/musicbrainz/convert.go
@@ -47,7 +47,7 @@ func NewConverter(db *sql.DB, store *meta.Store) *Converter {
 // ConvertArtists reads all artists from the database, converts them to META
 // objects, stores them in the META store and sends their CIDs to the given
 // stream.
-func (c *Converter) ConvertArtists(ctx context.Context, outStream chan *cid.Cid) error {
+func (c *Converter) ConvertArtists(ctx context.Context, outStream chan *cid.Cid, source string) error {
 	// get all artists from the db
 	rows, err := c.db.Query(artistsQuery)
 	if err != nil {
@@ -117,6 +117,7 @@ func (c *Converter) ConvertArtists(ctx context.Context, outStream chan *cid.Cid)
 			a.Annotation = strings.Split(string(annotation)[1:len(annotation)-1], ",")
 		}
 		a.Context = ArtistContext
+		a.Source = source
 
 		// convert the artist to a META object
 		obj, err := c.store.Put(a)

--- a/musicbrainz/types.go
+++ b/musicbrainz/types.go
@@ -19,6 +19,8 @@
 
 package musicbrainz
 
+import "github.com/meta-network/go-meta"
+
 // Context represents a JSON-LD context.
 type Context map[string]string
 
@@ -43,6 +45,8 @@ var ArtistContext = Context{
 // Artist represents a MusicBrainz artist, see
 // https://musicbrainz.org/doc/Artist
 type Artist struct {
+	meta.BaseObject
+
 	Context               Context  `json:"@context"`
 	ID                    int64    `json:"id,omitempty"`
 	Name                  string   `json:"name,omitempty"`

--- a/xmlschema/schema.go
+++ b/xmlschema/schema.go
@@ -26,64 +26,64 @@ import "github.com/ipfs/go-cid"
 
 // Generated with:
 //
-// $ meta import xsd xs \
+// $ meta convert --source jaak xsd xs \
 //     https://www.w3.org/2009/XMLSchema \
 //     <(curl -fSL https://www.w3.org/2009/XMLSchema/XMLSchema.xsd)
 //
 var XML_Schema = Schema{
 	URI: "http://www.w3.org/2001/XMLSchema",
-	Cid: mustCid("zdpuAniQsjiwxZyLdBBsqhTbrf2YTuoZNnXQctZrYytAFUU7D"),
+	Cid: mustCid("zdpuAnjGXP3KzAa6xU8qawMBSC1ASK77Ee4jSNQSk476W6MiM"),
 }
 
 // Generated with:
 //
-// $ meta import xsd ds \
+// $ meta convert --source jaak xsd ds \
 //     http://www.w3.org/2000/09/xmldsig# \
 //     <(curl -fSL https://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd)
 //
 var XML_Dsig = Schema{
 	URI: "http://www.w3.org/2000/09/xmldsig#",
-	Cid: mustCid("zdpuAz5xgov4sKBWFXvXz5h9kLAX2Tqnt2yBD6Ea79Wq3exfu"),
+	Cid: mustCid("zdpuAtmkeNCmihFUWBSpvuf45LMKTbQdo5KN11bmhkashhwua"),
 }
 
 // Generated with:
 //
-// $ meta import xsd avs http://ddex.net/xml/avs/avs
+// $ meta convert --source jaak xsd avs http://ddex.net/xml/avs/avs
 //
 var DDEX_Avs = Schema{
 	URI: "http://ddex.net/xml/avs/avs",
-	Cid: mustCid("zdpuAyfSqxq1pSSumk2QKFuz28HCkTaRmngvV52ku6Rsdq4Nh"),
+	Cid: mustCid("zdpuAnKnGMzEK4cN7izfSmB7ssoKhZKSTywTP9WATQSmvoyvL"),
 }
 
 // Generated with:
 //
-// $ meta import xsd ern \
+// $ meta convert --source jaak xsd ern \
 //     http://ddex.net/xml/ern/382 \
 //     <(curl -fSL http://service.ddex.net/xml/ern/382/release-notification.xsd)
 //
 var DDEX_Ern382 = Schema{
 	URI: "http://ddex.net/xml/ern/382",
-	Cid: mustCid("zdpuAo4f7WzDbiHVfigrWoywgzZB3xegd4Vc9BczgjJBUgaK7"),
+	Cid: mustCid("zdpuB3aicZm3xoRkdgUbzqMT2UR53d2gTBbbTa4JJ9ZmjRSqq"),
 }
 
 // Generated with:
 //
-// $ meta import xsd eidr \
+// $ meta convert --source jaak xsd eidr \
 //	http://www.eidr.org/schema \
 //	<(curl http://www.eidr.org/schema/common.xsd)
 var EIDR_common = Schema{
 	URI: "http://www.eidr.org/schema",
-	Cid: mustCid("zdpuAxFejco7Jim9RaKCE5UyBDdJYVKp4az5UVB8ZcYjrNWpJ"),
+	Cid: mustCid("zdpuAsNTSYmrkT1rFAnCWFtNp4Sa1G7LEgMj27NBHb5FL8hgU"),
 }
 
 // Generated with:
-// $ meta import xsd md \
+// $ meta convert --source jaak xsd md \
 //	http://www.movielabs.com/schema/md/v2.1/md \
 // 	<(curl http://www.eidr.org/schema/md-v21-eidr.xsd)
 //
 var EIDR_md = Schema{
 	URI: "http://www.movielabs.com/schema/md/v2.1/md",
-	Cid: mustCid("zdpuAqqfUHqQDEzCj8nDLxdmXiqpKXJ9vCVrZRrK8e8MewRRj"),
+	Cid: mustCid("zdpuAxvkAEi1PyWZ6mMbU3SWJkYP8YqyBtxauY4tywFKo29iZ"),
 }
 
 type Schema struct {


### PR DESCRIPTION
This adds the `@source` property to all objects which attributes the object creation to some source.

Long term we want this property to be a META ID, but for now we are just inserting a string until we have a tighter integration with META ID.

I've refactored the command line so all conversion commands are nested under `meta convert`, index commands under `meta index` and also consolidated the index flags for `meta server` into a single `--index` flag which can be set multiple times (e.g. `--index ern:path/to/ern.db --index cwr:path/to/cwr.db`).

The `xml` package now defines a converter rather than an importer which is more inline with the rest of the codebase.